### PR TITLE
Updated model class name for consistency with the .config files

### DIFF
--- a/dataset/parametric_img2refmap.py
+++ b/dataset/parametric_img2refmap.py
@@ -8,7 +8,7 @@ import cv2
 import numpy as np
 import torch
 
-from models.obsnet import ObsNetDiffuion
+from models.obsnet import ObsNetDiffusion
 from utils.file_io import load_exr
 from utils.transform import thetaphi2xyz
 
@@ -61,7 +61,7 @@ class ParametricImg2RefmapDataset(BaseDataset):
         self.generator = torch.Generator()
         self.current_epoch = 0
 
-        self.model: ObsNetDiffuion = None
+        self.model: ObsNetDiffusion = None
         self.refmap_key = refmap_key
 
         self.epoch_bias = epoch_bias

--- a/dataset/parametricrefmap.py
+++ b/dataset/parametricrefmap.py
@@ -6,7 +6,7 @@ import cv2
 import torch
 
 from models.drmnet import DRMNet
-from models.obsnet import ObsNetDiffuion
+from models.obsnet import ObsNetDiffusion
 from utils.file_io import load_exr
 from utils.transform import thetaphi2xyz
 
@@ -59,7 +59,7 @@ class ParametricRefmapDataset(BaseDataset):
         self.generator = torch.Generator()
         self.current_epoch = 0
 
-        self.model: Union[DRMNet, ObsNetDiffuion] = None
+        self.model: Union[DRMNet, ObsNetDiffusion] = None
 
         self.return_cache = return_cache
         self.epoch_bias = epoch_bias

--- a/models/obsnet.py
+++ b/models/obsnet.py
@@ -32,7 +32,7 @@ if mi.variant() is not None:
     from utils.mitsuba3_utils import MitsubaOrthoRenderer, MitsubaRefMapRenderer
 
 
-class ObsNetDiffuion(LatentDiffusion):
+class ObsNetDiffusion(LatentDiffusion):
     """inpainting class"""
 
     def __init__(

--- a/scripts/estimate.py
+++ b/scripts/estimate.py
@@ -104,9 +104,9 @@ def estimate(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("input_img", type=Path, help="The path of HDR image for an object (.exr, .hdr)")
-    parser.add_argument("input_normal", type=Path, help="The path of normal map for an object (.npy)")
-    parser.add_argument("input_mask", type=Path, help="The path of mask for an object (.png)", default=None)
+    parser.add_argument("--input_img", type=Path, help="The path of HDR image for an object (.exr, .hdr)")
+    parser.add_argument("--input_normal", type=Path, help="The path of normal map for an object (.npy)")
+    parser.add_argument("--input_mask", type=Path, help="The path of mask for an object (.png)", default=None)
     parser.add_argument(
         "--obsnet_base_path", type=Path, help="the config path for obsnet", default=Path("./configs/obsnet/eval_obsnet.yaml")
     )

--- a/scripts/estimate.py
+++ b/scripts/estimate.py
@@ -19,7 +19,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 from dataset.basedataset import BaseDataset
 from ldm.util import instantiate_from_config
 from models.drmnet import DRMNet
-from models.obsnet import ObsNetDiffuion
+from models.obsnet import ObsNetDiffusion
 from utils.file_io import load_exr, load_png, save_png
 from utils.img2refmap import refmap_mask_make
 from utils.mitsuba3_utils import get_bsdf, visualize_bsdf
@@ -28,7 +28,7 @@ from utils.tonemap import hdr2ldr
 
 def estimate(
     DRMNet_model: DRMNet,
-    ObsNet_model: ObsNetDiffuion,
+    ObsNet_model: ObsNetDiffusion,
     input_img: torch.Tensor,
     input_normal: torch.Tensor,
     mask: torch.Tensor,
@@ -118,7 +118,7 @@ if __name__ == "__main__":
 
     # load models
     obsnet_base_config = OmegaConf.load(args.obsnet_base_path)
-    obsnet_model: ObsNetDiffuion = instantiate_from_config(obsnet_base_config.model).cuda()
+    obsnet_model: ObsNetDiffusion = instantiate_from_config(obsnet_base_config.model).cuda()
     obsnet_model.ds: BaseDataset = instantiate_from_config(obsnet_base_config.data.params.predict)
     drmnet_base_config = OmegaConf.load(args.drmnet_base_path)
     drmnet_model: DRMNet = instantiate_from_config(drmnet_base_config.model).cuda()


### PR DESCRIPTION
In the config files the model is called models.obsnet.ObsNetDiffusion, while in the code it was originally ObsNetDiffuion.
Also added argument parser to specify inputs for evaluation.