### PR TITLE
Fixed environment files and revised README to address errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please cite the following paper, if you use any part of our code and data.
 
 ## Requirements
 
-We tested our code with Python 3.6 on Ubuntu 20.04 LTS using the following packages.
+We tested our code with Python 3.8 on Ubuntu 20.04 LTS using the following packages.
 
 - numpy==1.23.5
 - pytorch==1.12.1
@@ -37,7 +37,7 @@ Please refer to [environment/pip_freeze.txt](environment/pip_freeze.txt) for the
 
 You can also use `singularity` to replicate our environment:
 ```bash
-singularity build environment/drmnet.sif environment/drmnet.def
+singularity build environment/drmnet.sif environment/drmnet_release.def
 singularity run --nv environment/drmnet.sif
 ```
 
@@ -49,7 +49,7 @@ You can download the pretrained models (`drmnet.ckpt` and `obsnet.ckpt`) from [h
 You can apply the model on the sample data in the `data` directory by running the script below.
 
 ```bash
-python scripts/estimate.py ./data/sample/image.exr ./data/sample/normal.npy ./data/sample/mask.png
+python scripts/estimate.py --input_img ./data/sample/image.exr --input_normal ./data/sample/normal.npy --input_mask ./data/sample/mask.png
 ```
 
 You can view the outputs in `outputs`.
@@ -116,7 +116,7 @@ python scripts/preprocess_shape.py <PATH_TO_Shapes_Multi_5000>
 
 You can train DRMNet by running
 ```bash
-python main.py --base ./configs/inpainting/train_drmnet.yaml -t --device 0
+python main.py --base ./configs/drmnet/train_drmnet.yaml -t --device 0
 ```
 The logs and checkpoints are saved to `logs/<START_DATE_AND_TIME>_train_drmnet`.
 
@@ -124,7 +124,7 @@ The logs and checkpoints are saved to `logs/<START_DATE_AND_TIME>_train_drmnet`.
 
 You can train ObsNet by running
 ```bash
-python main.py --base ./configs/inpainting/train_obsnet.yaml -t --device 0
+python main.py --base ./configs/obsnet/train_obsnet.yaml -t --device 0
 ```
 The logs and checkpoints are saved to `./logs/<START_DATE_AND_TIME>_train_obsnet`.
 
@@ -132,7 +132,7 @@ In order to finetune the ObsNet model, you need to modify the configuration file
 The default value for `model: params: ckpt_path` is set to `./logs/xxxx-xx-xxTxx-xx-xx_train_obsnet/checkpoints/last.ckpt`.
 To finetune the network using raw reflectance maps from random object images, update this path with the above directory and run:
 ```bash
-python main.py --base ./configs/inpainting/finetune_obsnet.yaml -t --device 0
+python main.py --base ./configs/obsnet/finetune_obsnet.yaml -t --device 0
 ```
 .
 The logs and checkpoints are saved to `./logs/<START_DATE_AND_TIME>_finetune_obsnet`.

--- a/environment/drmnet_release.def
+++ b/environment/drmnet_release.def
@@ -43,7 +43,7 @@ From: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
     pip install --no-cache-dir albumentations pudb imageio imageio-ffmpeg scikit-image lpips
     pip install --no-cache-dir pytorch-lightning==1.9.0
     pip install --no-cache-dir omegaconf streamlit torch-fidelity einops transformers
-    pip install --no-cache-dir pynvrtc
+    pip install --no-cache-dir pynvrtc==9.2
     pip install --no-cache-dir matplotlib scikit-learn tqdm
     pip install --no-cache-dir Pillow tensorboard
     pip install --no-cache-dir pytorch-fid
@@ -51,7 +51,7 @@ From: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
 
     # build mitsuba3
     cd /opt
-    git clone --branch v3.2.0 --recursive https://github.com/mitsuba-renderer/mitsuba3
+    git clone --branch v3.3.0 --recursive https://github.com/mitsuba-renderer/mitsuba3
     cd mitsuba3
     apt-get install -y clang-10 libc++-10-dev libc++abi-10-dev cmake ninja-build
     apt-get install -y libpng-dev libjpeg-dev

--- a/environment/pip_freeze.txt
+++ b/environment/pip_freeze.txt
@@ -86,7 +86,7 @@ six==1.16.0
 smmap==5.0.1
 streamlit==1.32.0
 # Editable Git install with no remote (taming-transformers==0.0.1)
--e /src/taming-transformers
+-e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
 tenacity==8.2.3
 tensorboard==2.14.0
 tensorboard-data-server==0.7.2
@@ -95,10 +95,10 @@ tifffile==2023.7.10
 tokenizers==0.15.2
 toml==0.10.2
 toolz==0.12.1
-torch==1.12.1+cu113
+torch==1.12.1
 torch-fidelity==0.3.0
 torchmetrics==1.3.1
-torchvision==0.13.1+cu113
+torchvision==0.13.1
 tornado==6.4
 tqdm==4.66.2
 transformers==4.38.2


### PR DESCRIPTION
I made changes to the following three files:

- environment/drmnet_release.def
Specified the Pynvrtc version to avoid errors related to yanked versions.
Upgraded the Mitsuba3 version from v3.2.0 to v3.3.0 (and Dr.Jit to v0.4.2) to fix a critical issue with the dr.jit compiler that occurred during the 82nd epoch of training.

- environment/pip_freeze.txt
Added a link to taming-transformers to ensure it is installed correctly.

- README
Tested the code with Python 3.8, which is compatible with PyTorch Lightning 1.9.
The demo script was inconsistent with the file name and argument parser, which has been updated to properly specify inputs for evaluation.
Fixed some incorrect file paths in training scripts.